### PR TITLE
Update custom.less

### DIFF
--- a/less/custom.less
+++ b/less/custom.less
@@ -20,8 +20,8 @@
 .DiscussionListItem {
   .TagsUnderDiscussion {
     display: inline-block !important;
-    margin-top: -8px !important;
-    margin-bottom: 8px !important;
+    margin-top: -4px !important;
+    margin-bottom: 5px !important;
     vertical-align: middle;
   }
 }


### PR DESCRIPTION
fixes an issue where tags would push up into the excerpt cutting off the top of the tag name.

<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->


**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![before](https://github.com/user-attachments/assets/282e3ef1-961f-40f9-8714-2f69065bf578)

![after](https://github.com/user-attachments/assets/02d95e19-de16-413a-90e2-dca8dda96290)

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Maintainer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
